### PR TITLE
modifying loop implementation according to description in text

### DIFF
--- a/_posts/2017-01-02-Protocol-Oriented-Programming.md
+++ b/_posts/2017-01-02-Protocol-Oriented-Programming.md
@@ -255,8 +255,11 @@ do {
         
         let classPointerSize = MemoryLayout<EmployeeClass>.size
         let classHeapSize = _swift_stdlib_malloc_size(unsafeBitCast(variable, to: UnsafePointer<CChar>.self))
-        classLoopMemoryUsage += classPointerSize + classHeapSize
+        classLoopMemoryUsage += classHeapSize
     }
+
+    let classPointerSize = MemoryLayout<EmployeeClass>.size
+    classLoopMemoryUsage += classPointerSize
     
     print("Used \(classLoopMemoryUsage) bytes reusing variable for class")
 }


### PR DESCRIPTION
according to text: "Since creating a class always allocates memory on the heap, reusing a variable only recycles the bytes needed for the pointer to the data on the heap (a pointer is typically one byte)."

shouldn't implementation just accumulate classHeapSize for every loop?