### PR TITLE
remove fullName property from original Person protocol

### DIFF
--- a/_posts/2017-01-02-Protocol-Oriented-Programming.md
+++ b/_posts/2017-01-02-Protocol-Oriented-Programming.md
@@ -288,7 +288,6 @@ protocol Person {
     var identifier: Int { get }
     var firstName: String { get }
     var lastName: String { get }
-    var fullName: String { get }
 }
 
 extension Person {


### PR DESCRIPTION
fullName property is added by extension, should not be present in original Protocol